### PR TITLE
Configure character-stage as library

### DIFF
--- a/character-stage/package.json
+++ b/character-stage/package.json
@@ -2,9 +2,10 @@
   "name": "chub-character-creator-stage",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build --base=/chubgen/character-stage/"
+    "build": "tsc && vite build --mode lib"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/character-stage/src/index.ts
+++ b/character-stage/src/index.ts
@@ -1,0 +1,1 @@
+export { Stage } from './Stage';

--- a/character-stage/vite.config.ts
+++ b/character-stage/vite.config.ts
@@ -1,15 +1,24 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 
-// Vite configuration for building the character-stage as a static site.
-// The `base` option ensures that all asset URLs are prefixed with the
-// repository path when served via GitHub Pages (e.g. https://vg126.github.io/chubgen/character-stage/).
-export default defineConfig({
-  plugins: [react()],
-  // When deploying to GitHub Pages we need to set the base path so that
-  // links to JavaScript and CSS assets are resolved correctly.
-  base: '/chubgen/character-stage/',
-  build: {
-    outDir: 'dist'
+export default defineConfig(({ command, mode }) => {
+  if (mode !== 'lib') {
+    return { plugins: [react()] };
   }
+  return {
+    plugins: [react()],
+    build: {
+      lib: {
+        entry: resolve(__dirname, 'src/index.ts'),
+        name: 'index',
+        formats: ['umd', 'es', 'cjs', 'iife'],
+        fileName: 'index'
+      },
+      rollupOptions: {
+        external: ['react', 'react-dom'],
+        output: { globals: { react: 'React', 'react-dom': 'ReactDOM' } }
+      }
+    }
+  };
 });


### PR DESCRIPTION
## Summary
- expose Stage component via `src/index.ts`
- switch `character-stage` build to library mode

## Testing
- `npm run build` *(fails: TS2322 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b18fe925083328d22a4d9c0046a71