### PR TITLE
Add character stage README

### DIFF
--- a/character-stage/README.md
+++ b/character-stage/README.md
@@ -1,0 +1,20 @@
+# Character Stage
+
+This directory contains a minimal example stage built with React. It demonstrates how a Chub.AI stage can provide a small character creation interface.
+
+## Setup
+
+```bash
+yarn install
+yarn dev
+```
+
+The `dev` script runs Vite for local development.
+
+## Build and Deployment
+
+A GitHub Actions workflow (`.github/workflows/deploy.yml`) automatically builds the stage and commits the compiled assets when changes are pushed to `main`. The built files are served via GitHub Pages.
+
+## Official Template Reference
+
+See [`stage-template-reference`](../stage-template-reference) or the [official stage-template repository](https://github.com/CharHubAI/stage-template) for a full reference implementation.


### PR DESCRIPTION
## Summary
- document how to run the example Stage
- note build & GitHub Pages deployment
- link to the official stage template

## Testing
- `yarn install` in `character-stage`
- `yarn build` *(fails: Rollup could not resolve "/chubgen/character-stage/assets/index-50764e83.js" from "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_688b1915d9608332ad239331d89bc05c